### PR TITLE
Add env-based DB configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,5 @@
+# Example environment configuration for TitanAxis
+DATABASE_URL=jdbc:mariadb://localhost:3306/titanaxis_db
+DATABASE_USER=titan_user
+DATABASE_PASSWORD=titanpass
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# TitanAxis
+
+TitanAxis is a desktop application that relies on a MariaDB database. The application will read connection details from the environment when available and fall back to `src/main/resources/config.properties` otherwise.
+
+## Environment variables
+
+Set the following variables to configure the database connection:
+
+- `DATABASE_URL` – JDBC connection URL
+- `DATABASE_USER` – database user
+- `DATABASE_PASSWORD` – database user's password
+
+These variables can be placed in a `.env` file or configured in your deployment environment. When not provided, the values defined in `config.properties` are used.
+
+## Running with Docker
+
+The project includes a `docker-compose.yml` that starts a MariaDB instance. You can create a `.env` file based on `.env.sample` to override the default credentials.
+
+```bash
+docker compose up -d
+```


### PR DESCRIPTION
## Summary
- load database credentials from environment variables with config file fallback
- document expected environment variables
- provide `.env.sample` for Docker/compose setups

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6888c685a618832495a7ab6f4bc6c6ae