### PR TITLE
Add unit tests for service layer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,24 @@
             <version>5.10.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -165,6 +183,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
 
         </plugins>

--- a/src/test/java/com/titanaxis/service/CategoriaServiceTest.java
+++ b/src/test/java/com/titanaxis/service/CategoriaServiceTest.java
@@ -1,0 +1,37 @@
+package com.titanaxis.service;
+
+import com.titanaxis.exception.PersistenciaException;
+import com.titanaxis.model.Categoria;
+import com.titanaxis.repository.CategoriaRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class CategoriaServiceTest {
+
+    @Test
+    void listarTodasCategorias_uses_repository() throws PersistenciaException {
+        CategoriaRepository repo = mock(CategoriaRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        CategoriaService service = new CategoriaService(repo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        List<Categoria> categorias = List.of(new Categoria(1, "teste"));
+        when(repo.findAllWithProductCount(em)).thenReturn(categorias);
+        when(txService.executeInTransactionWithResult(any())).thenAnswer(invocation -> {
+            Function<EntityManager, List<Categoria>> func = invocation.getArgument(0);
+            return func.apply(em);
+        });
+
+        List<Categoria> result = service.listarTodasCategorias();
+        assertEquals(categorias, result);
+        verify(repo).findAllWithProductCount(em);
+    }
+}

--- a/src/test/java/com/titanaxis/service/TransactionServiceTest.java
+++ b/src/test/java/com/titanaxis/service/TransactionServiceTest.java
@@ -1,0 +1,58 @@
+package com.titanaxis.service;
+
+import com.titanaxis.exception.PersistenciaException;
+import com.titanaxis.util.JpaUtil;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.PersistenceException;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class TransactionServiceTest {
+
+    @Test
+    void executeInTransactionWithResult_commits_on_success() throws PersistenciaException {
+        EntityManager em = mock(EntityManager.class);
+        EntityTransaction tx = mock(EntityTransaction.class);
+        when(em.getTransaction()).thenReturn(tx);
+        MockedStatic<JpaUtil> utilMock = mockStatic(JpaUtil.class);
+        utilMock.when(JpaUtil::getEntityManager).thenReturn(em);
+        TransactionService service = new TransactionService();
+
+        Function<EntityManager, String> function = e -> "ok";
+        String result = service.executeInTransactionWithResult(function);
+
+        assertEquals("ok", result);
+        verify(tx).begin();
+        verify(tx).commit();
+        verify(tx, never()).rollback();
+        verify(em).close();
+        utilMock.close();
+    }
+
+    @Test
+    void executeInTransactionWithResult_rolls_back_on_persistence_exception() {
+        EntityManager em = mock(EntityManager.class);
+        EntityTransaction tx = mock(EntityTransaction.class);
+        when(em.getTransaction()).thenReturn(tx);
+        doThrow(new PersistenceException("fail"))
+                .when(tx).commit();
+
+        try (MockedStatic<JpaUtil> utilMock = mockStatic(JpaUtil.class)) {
+            utilMock.when(JpaUtil::getEntityManager).thenReturn(em);
+            TransactionService service = new TransactionService();
+
+            assertThrows(PersistenciaException.class,
+                    () -> service.executeInTransactionWithResult(e -> "value"));
+
+            verify(tx).begin();
+            verify(tx).rollback();
+            verify(em).close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set up surefire and Mockito
- add JUnit tests for TransactionService
- add simple mock-based test for CategoriaService

## Testing
- `mvn -e -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888c6bb61108324a953233b6094fcd5