### PR TITLE
Add unit tests for services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>5.11.0</version>
             <scope>test</scope>

--- a/src/test/java/com/titanaxis/service/AuthServiceTest.java
+++ b/src/test/java/com/titanaxis/service/AuthServiceTest.java
@@ -1,0 +1,48 @@
+package com.titanaxis.service;
+
+import com.titanaxis.exception.PersistenciaException;
+import com.titanaxis.model.NivelAcesso;
+import com.titanaxis.model.Usuario;
+import com.titanaxis.repository.AuditoriaRepository;
+import com.titanaxis.repository.UsuarioRepository;
+import com.titanaxis.util.PasswordUtil;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class AuthServiceTest {
+
+    @Test
+    void login_success_returns_user_and_records_audit() throws PersistenciaException {
+        UsuarioRepository userRepo = mock(UsuarioRepository.class);
+        AuditoriaRepository auditRepo = mock(AuditoriaRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        AuthService service = new AuthService(userRepo, auditRepo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        String hash = PasswordUtil.hashPassword("secret");
+        Usuario user = new Usuario(1, "admin", hash, NivelAcesso.ADMIN);
+
+        when(txService.executeInTransactionWithResult(any())).thenAnswer(inv -> {
+            Function<EntityManager, Optional<Usuario>> func = inv.getArgument(0);
+            return func.apply(em);
+        });
+        doAnswer(inv -> { Consumer<EntityManager> c = inv.getArgument(0); c.accept(em); return null; })
+                .when(txService).executeInTransaction(any());
+        when(userRepo.findByNomeUsuario("admin", em)).thenReturn(Optional.of(user));
+
+        Optional<Usuario> result = service.login("admin", "secret");
+
+        assertTrue(result.isPresent());
+        assertEquals(user, result.get());
+        verify(userRepo).findByNomeUsuario("admin", em);
+        verify(auditRepo).registrarAcao(eq(user.getId()), eq("admin"), eq("LOGIN_SUCESSO"), eq("Autenticação"), anyString(), eq(em));
+    }
+}

--- a/src/test/java/com/titanaxis/service/FinanceiroServiceTest.java
+++ b/src/test/java/com/titanaxis/service/FinanceiroServiceTest.java
@@ -1,0 +1,61 @@
+package com.titanaxis.service;
+
+import com.titanaxis.exception.PersistenciaException;
+import com.titanaxis.model.ContasAReceber;
+import com.titanaxis.repository.FinanceiroRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class FinanceiroServiceTest {
+
+    @Test
+    void listarContasAReceber_uses_repository() throws PersistenciaException {
+        FinanceiroRepository repo = mock(FinanceiroRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        FinanceiroService service = new FinanceiroService(repo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        List<ContasAReceber> contas = List.of(new ContasAReceber());
+        when(txService.executeInTransactionWithResult(any())).thenAnswer(inv -> {
+            Function<EntityManager, List<ContasAReceber>> func = inv.getArgument(0);
+            return func.apply(em);
+        });
+        when(repo.findContasAReceber(true, em)).thenReturn(contas);
+
+        List<ContasAReceber> result = service.listarContasAReceber(true);
+
+        assertEquals(contas, result);
+        verify(repo).findContasAReceber(true, em);
+    }
+
+    @Test
+    void registrarPagamento_updates_status_and_saves() throws PersistenciaException {
+        FinanceiroRepository repo = mock(FinanceiroRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        FinanceiroService service = new FinanceiroService(repo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        ContasAReceber conta = new ContasAReceber();
+        conta.setStatus("Pendente");
+        when(repo.findContaAReceberById(5, em)).thenReturn(Optional.of(conta));
+        doAnswer(inv -> { Consumer<EntityManager> c = inv.getArgument(0); c.accept(em); return null; })
+                .when(txService).executeInTransaction(any());
+
+        service.registrarPagamento(5);
+
+        assertEquals("Pago", conta.getStatus());
+        assertNotNull(conta.getDataPagamento());
+        verify(repo).saveContaAReceber(conta, em);
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthServiceTest and FinanceiroServiceTest to cover login and financial workflows
- enable Mockito inline mocking for static calls

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888db6cb63c8324ab8c6267afac6c72