### PR TITLE
Improve logging

### DIFF
--- a/src/main/java/com/titanaxis/presenter/DashboardDataWorker.java
+++ b/src/main/java/com/titanaxis/presenter/DashboardDataWorker.java
@@ -9,6 +9,7 @@ import com.titanaxis.service.AnalyticsService;
 import com.titanaxis.service.UserHabitService;
 import com.titanaxis.view.DashboardFrame;
 import com.titanaxis.view.panels.HomePanel;
+import com.titanaxis.util.AppLogger;
 
 import javax.swing.*;
 import java.time.LocalDate;
@@ -16,6 +17,7 @@ import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
 
 public class DashboardDataWorker extends SwingWorker<DashboardData, Void> {
 
@@ -23,6 +25,7 @@ public class DashboardDataWorker extends SwingWorker<DashboardData, Void> {
     private final DashboardFrame parentFrame;
     private final AppContext appContext;
     private final String chartPeriod;
+    private static final Logger logger = AppLogger.getLogger();
 
     public DashboardDataWorker(HomePanel homePanel, AppContext appContext, String chartPeriod, DashboardFrame parentFrame) {
         this.homePanel = homePanel;
@@ -68,7 +71,7 @@ public class DashboardDataWorker extends SwingWorker<DashboardData, Void> {
             DashboardData data = get();
             homePanel.updateUI(data);
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Falha ao obter dados do dashboard.", e);
             homePanel.showErrorState(e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
         } finally {
             homePanel.setLoadingState(false);

--- a/src/main/java/com/titanaxis/view/panels/MovimentosPanel.java
+++ b/src/main/java/com/titanaxis/view/panels/MovimentosPanel.java
@@ -4,6 +4,7 @@ import com.titanaxis.app.AppContext;
 import com.titanaxis.model.MovimentoEstoque;
 import com.titanaxis.util.I18n;
 import com.titanaxis.util.UIMessageUtil;
+import com.titanaxis.util.AppLogger;
 import com.titanaxis.view.dialogs.VendaDetalhesDialog;
 import com.titanaxis.view.interfaces.MovimentoView;
 import com.titanaxis.view.renderer.MovimentoTableCellRenderer;
@@ -20,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import org.slf4j.Logger;
 
 public class MovimentosPanel extends JPanel implements MovimentoView {
     private MovimentoViewListener listener;
@@ -27,6 +29,7 @@ public class MovimentosPanel extends JPanel implements MovimentoView {
     private final JTable table;
     private final TableRowSorter<DefaultTableModel> sorter;
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
+    private static final Logger logger = AppLogger.getLogger();
 
     private JSpinner dataInicioSpinner;
     private JSpinner dataFimSpinner;
@@ -110,7 +113,7 @@ public class MovimentosPanel extends JPanel implements MovimentoView {
                             () -> UIMessageUtil.showWarningMessage(this, I18n.getString("movement.error.detailsNotFound"), I18n.getString("warning.title"))
                     );
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Erro ao abrir detalhes de venda.", e);
             UIMessageUtil.showErrorMessage(this, I18n.getString("movement.error.unexpectedDetails", e.getMessage()), I18n.getString("error.critical.title"));
         }
     }


### PR DESCRIPTION
## Summary
- log errors instead of printing stack traces
- set up loggers for dashboard and movimentos panels

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6888db5c729483248aaae863dae0a661