### PR TITLE
Fix duplicate password entry

### DIFF
--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,4 +1,3 @@
 database.password=titanpass
 database.url=jdbc:mariadb://localhost:3306/titanaxis_db
 database.user=titan_user
-database.password=titanpass


### PR DESCRIPTION
## Summary
- remove repeated database.password in config

## Testing
- `mvn -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888db5ae3c48324b1db0f474dae2833