### PR TITLE
Load DB credentials from environment or properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TitanAxis
 
-TitanAxis is a desktop application that relies on a MariaDB database. The application will read connection details from the environment when available and fall back to `src/main/resources/config.properties` otherwise.
+TitanAxis is a desktop application that relies on a MariaDB database. Connection details are now supplied at runtime from environment variables or from `src/main/resources/config.properties` when the variables are not present.
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
 
 ## Prerequisites
@@ -11,13 +11,13 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 ## Environment variables
 
-Set the following variables to configure the database connection:
+Set the following variables to configure the database connection (or edit `config.properties` using the same keys):
 
 - `DATABASE_URL` – JDBC connection URL
 - `DATABASE_USER` – database user
 - `DATABASE_PASSWORD` – database user's password
 
-These variables can be placed in a `.env` file or configured in your deployment environment. When not provided, the values defined in `config.properties` are used.
+These variables can be placed in a `.env` file or configured in your deployment environment. When not provided, the values defined in `config.properties` are used. The `persistence.xml` file no longer stores credentials so they must be provided by one of these methods.
 
 ## Running with Docker
 

--- a/src/main/java/com/titanaxis/util/JpaUtil.java
+++ b/src/main/java/com/titanaxis/util/JpaUtil.java
@@ -4,18 +4,40 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public class JpaUtil {
 
+    private static final Properties config = new Properties();
     private static final EntityManagerFactory entityManagerFactory;
 
     static {
+        try (InputStream in = JpaUtil.class.getClassLoader().getResourceAsStream("config.properties")) {
+            if (in != null) {
+                config.load(in);
+            }
+        } catch (IOException e) {
+            System.err.println("Erro ao ler config.properties: " + e.getMessage());
+        }
+
         try {
-            // O nome "TitanAxisPU" deve ser o mesmo do persistence.xml
-            entityManagerFactory = Persistence.createEntityManagerFactory("TitanAxisPU");
+            Properties props = new Properties();
+            props.setProperty("jakarta.persistence.jdbc.url", getEnvOrProperty("DATABASE_URL", "database.url"));
+            props.setProperty("jakarta.persistence.jdbc.user", getEnvOrProperty("DATABASE_USER", "database.user"));
+            props.setProperty("jakarta.persistence.jdbc.password", getEnvOrProperty("DATABASE_PASSWORD", "database.password"));
+
+            entityManagerFactory = Persistence.createEntityManagerFactory("TitanAxisPU", props);
         } catch (Throwable ex) {
             System.err.println("Falha ao criar o EntityManagerFactory." + ex);
             throw new ExceptionInInitializerError(ex);
         }
+    }
+
+    private static String getEnvOrProperty(String env, String propKey) {
+        String val = System.getenv(env);
+        return val != null ? val : config.getProperty(propKey);
     }
 
     public static EntityManager getEntityManager() {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -22,9 +22,6 @@
 
         <properties>
             <property name="jakarta.persistence.jdbc.driver" value="org.mariadb.jdbc.Driver"/>
-            <property name="jakarta.persistence.jdbc.url" value="jdbc:mariadb://localhost:3306/titanaxis_db"/>
-            <property name="jakarta.persistence.jdbc.user" value="titan_user"/>
-            <property name="jakarta.persistence.jdbc.password" value="titanpass"/>
 
             <property name="hibernate.connection.provider_class" value="org.hibernate.hikaricp.internal.HikariCPConnectionProvider"/>
             <property name="hibernate.hikari.minimumIdle" value="5"/>


### PR DESCRIPTION
## Summary
- read DB credentials in `JpaUtil` from environment variables or `config.properties`
- pass the properties into `Persistence.createEntityManagerFactory`
- remove hard-coded credentials from `persistence.xml`
- document runtime configuration options in README

## Testing
- `mvn test` *(fails: plugin resolution network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888edf8568c832489f2aecf39a9502c