### PR TITLE
Inject logger in JpaUtil

### DIFF
--- a/src/main/java/com/titanaxis/util/JpaUtil.java
+++ b/src/main/java/com/titanaxis/util/JpaUtil.java
@@ -3,9 +3,15 @@ package com.titanaxis.util;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
+import org.slf4j.Logger;
+
+import com.titanaxis.util.AppLogger;
+
+/** Utility class for managing the JPA EntityManagerFactory. */
 
 public class JpaUtil {
 
+    private static final Logger logger = AppLogger.getLogger();
     private static final EntityManagerFactory entityManagerFactory;
 
     static {
@@ -13,7 +19,7 @@ public class JpaUtil {
             // O nome "TitanAxisPU" deve ser o mesmo do persistence.xml
             entityManagerFactory = Persistence.createEntityManagerFactory("TitanAxisPU");
         } catch (Throwable ex) {
-            System.err.println("Falha ao criar o EntityManagerFactory." + ex);
+            logger.error("Falha ao criar o EntityManagerFactory.", ex);
             throw new ExceptionInInitializerError(ex);
         }
     }


### PR DESCRIPTION
## Summary
- inject logger into `JpaUtil`
- log initialization errors instead of printing to stderr

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6888ee149a58832494c905e8219034ef