### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Build with Maven
+        run: mvn -B clean verify


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that sets up JDK 21
- run `mvn -B clean verify` during CI

## Testing
- `mvn -B clean verify` *(fails: Network is unreachable for repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_6888ee25ea2483248ddac34a0db258cd