### PR TITLE
Add service unit tests

### DIFF
--- a/src/test/java/com/titanaxis/service/FinanceiroServiceTest.java
+++ b/src/test/java/com/titanaxis/service/FinanceiroServiceTest.java
@@ -2,11 +2,12 @@ package com.titanaxis.service;
 
 import com.titanaxis.exception.PersistenciaException;
 import com.titanaxis.model.ContasAReceber;
+import com.titanaxis.model.MetaVenda;
+import com.titanaxis.model.Venda;
 import com.titanaxis.repository.FinanceiroRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -16,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import org.mockito.ArgumentCaptor;
 
 public class FinanceiroServiceTest {
 
@@ -57,5 +59,83 @@ public class FinanceiroServiceTest {
         assertEquals("Pago", conta.getStatus());
         assertNotNull(conta.getDataPagamento());
         verify(repo).saveContaAReceber(conta, em);
+    }
+
+    @Test
+    void gerarContasAReceberParaVenda_creates_entries_for_each_parcel() {
+        FinanceiroRepository repo = mock(FinanceiroRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        FinanceiroService service = new FinanceiroService(repo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        Venda venda = new Venda();
+        venda.setFormaPagamento("A Prazo");
+        venda.setNumeroParcelas(3);
+        venda.setValorTotal(300.0);
+
+        service.gerarContasAReceberParaVenda(venda, em);
+
+        ArgumentCaptor<ContasAReceber> captor = ArgumentCaptor.forClass(ContasAReceber.class);
+        verify(repo, times(3)).saveContaAReceber(captor.capture(), eq(em));
+
+        List<ContasAReceber> contas = captor.getAllValues();
+        assertEquals(3, contas.size());
+        for (int i = 0; i < contas.size(); i++) {
+            ContasAReceber c = contas.get(i);
+            assertEquals(venda, c.getVenda());
+            assertEquals(i + 1, c.getNumeroParcela());
+            assertEquals(100.0, c.getValorParcela());
+            assertEquals("Pendente", c.getStatus());
+        }
+    }
+
+    @Test
+    void listarMetas_uses_repository() throws PersistenciaException {
+        FinanceiroRepository repo = mock(FinanceiroRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        FinanceiroService service = new FinanceiroService(repo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        List<MetaVenda> metas = List.of(new MetaVenda());
+        when(txService.executeInTransactionWithResult(any())).thenAnswer(inv -> {
+            Function<EntityManager, List<MetaVenda>> func = inv.getArgument(0);
+            return func.apply(em);
+        });
+        when(repo.findAllMetas(em)).thenReturn(metas);
+
+        List<MetaVenda> result = service.listarMetas();
+        assertEquals(metas, result);
+        verify(repo).findAllMetas(em);
+    }
+
+    @Test
+    void salvarMeta_calls_repository() throws PersistenciaException {
+        FinanceiroRepository repo = mock(FinanceiroRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        FinanceiroService service = new FinanceiroService(repo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        MetaVenda meta = new MetaVenda();
+        doAnswer(inv -> { Consumer<EntityManager> c = inv.getArgument(0); c.accept(em); return null; })
+                .when(txService).executeInTransaction(any());
+
+        service.salvarMeta(meta);
+
+        verify(repo).saveMeta(meta, em);
+    }
+
+    @Test
+    void deletarMeta_calls_repository() throws PersistenciaException {
+        FinanceiroRepository repo = mock(FinanceiroRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        FinanceiroService service = new FinanceiroService(repo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        doAnswer(inv -> { Consumer<EntityManager> c = inv.getArgument(0); c.accept(em); return null; })
+                .when(txService).executeInTransaction(any());
+
+        service.deletarMeta(10);
+
+        verify(repo).deleteMetaById(10, em);
     }
 }

--- a/src/test/java/com/titanaxis/service/RelatorioServiceTest.java
+++ b/src/test/java/com/titanaxis/service/RelatorioServiceTest.java
@@ -1,0 +1,114 @@
+package com.titanaxis.service;
+
+import com.titanaxis.exception.PersistenciaException;
+import com.titanaxis.model.*;
+import com.titanaxis.repository.AuditoriaRepository;
+import com.titanaxis.repository.ProdutoRepository;
+import com.titanaxis.repository.VendaRepository;
+import com.titanaxis.util.I18n;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Vector;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class RelatorioServiceTest {
+
+    @Test
+    void gerarRelatorioInventario_builds_csv() throws PersistenciaException {
+        ProdutoRepository prodRepo = mock(ProdutoRepository.class);
+        VendaRepository vendaRepo = mock(VendaRepository.class);
+        AuditoriaRepository auditRepo = mock(AuditoriaRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        RelatorioService service = new RelatorioService(prodRepo, vendaRepo, auditRepo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        Categoria cat = new Categoria(1, "Eletronicos");
+        Produto p = new Produto();
+        p.setId(1);
+        p.setNome("Notebook");
+        p.setPreco(10.0);
+        p.setCategoria(cat);
+        Lote l = new Lote();
+        l.setQuantidade(2);
+        p.setLotes(List.of(l));
+        List<Produto> produtos = List.of(p);
+
+        when(txService.executeInTransactionWithResult(any())).thenAnswer(inv -> {
+            Function<EntityManager, List<Produto>> func = inv.getArgument(0);
+            return func.apply(em);
+        });
+        when(prodRepo.findAllIncludingInactive(em)).thenReturn(produtos);
+
+        String csv = service.gerarRelatorioInventario();
+
+        String header = I18n.getString("report.inventory.header.id") + ";" +
+                I18n.getString("report.inventory.header.name") + ";" +
+                I18n.getString("report.inventory.header.category") + ";" +
+                I18n.getString("report.inventory.header.totalQty") + ";" +
+                I18n.getString("report.inventory.header.unitPrice") + ";" +
+                I18n.getString("report.inventory.header.totalValue") + "\n";
+        assertEquals(header + "1;\"Notebook\";\"Eletronicos\";2;10.00;20.00\n", csv);
+        verify(prodRepo).findAllIncludingInactive(em);
+    }
+
+    @Test
+    void gerarRelatorioVendas_builds_csv() throws PersistenciaException {
+        ProdutoRepository prodRepo = mock(ProdutoRepository.class);
+        VendaRepository vendaRepo = mock(VendaRepository.class);
+        AuditoriaRepository auditRepo = mock(AuditoriaRepository.class);
+        TransactionService txService = mock(TransactionService.class);
+        RelatorioService service = new RelatorioService(prodRepo, vendaRepo, auditRepo, txService);
+
+        EntityManager em = mock(EntityManager.class);
+        Usuario user = new Usuario();
+        user.setNomeUsuario("seller");
+        Cliente cliente = new Cliente();
+        cliente.setNome("John");
+        Venda venda = new Venda();
+        venda.setId(1);
+        venda.setUsuario(user);
+        venda.setCliente(cliente);
+        venda.setDataVenda(LocalDateTime.of(2024,1,1,10,0));
+        venda.setValorTotal(30.0);
+        List<Venda> vendas = List.of(venda);
+
+        when(txService.executeInTransactionWithResult(any())).thenAnswer(inv -> {
+            Function<EntityManager, List<Venda>> func = inv.getArgument(0);
+            return func.apply(em);
+        });
+        when(vendaRepo.findAll(em)).thenReturn(vendas);
+
+        String csv = service.gerarRelatorioVendas();
+
+        String header = I18n.getString("report.sales.header.id") + ";" +
+                I18n.getString("report.sales.header.date") + ";" +
+                I18n.getString("report.sales.header.client") + ";" +
+                I18n.getString("report.sales.header.user") + ";" +
+                I18n.getString("report.sales.header.totalValue") + "\n";
+        assertTrue(csv.startsWith(header));
+        assertTrue(csv.contains("\"John\""));
+        assertTrue(csv.contains("\"seller\""));
+        verify(vendaRepo).findAll(em);
+    }
+
+    @Test
+    void gerarRelatorioAuditoriaCsv_quotes_values() {
+        RelatorioService service = new RelatorioService(null, null, null, null);
+
+        Vector<Object> row = new Vector<>();
+        row.add("He said \"Hello\"");
+        row.add(5);
+        String[] headers = {"h1","h2"};
+
+        String csv = service.gerarRelatorioAuditoriaCsv(List.of(row), headers);
+
+        assertEquals("h1;h2\n\"He said \"\"Hello\"\"\";\"5\"\n", csv);
+    }
+}


### PR DESCRIPTION
## Summary
- expand FinanceiroServiceTest coverage
- add new RelatorioServiceTest

## Testing
- `mvn -q test` *(fails: PluginResolutionException - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6888ee2a892883248a24749189a77a6e